### PR TITLE
List available forms in /api/info endpoint

### DIFF
--- a/packages/form-builder/src/__tests__/local-deployment.test.ts
+++ b/packages/form-builder/src/__tests__/local-deployment.test.ts
@@ -18,10 +18,19 @@ interface ApiResponse {
   submissionId?: string;
 }
 
+interface FormInfo {
+  id: string;
+  name: string;
+  url: string;
+  apiUrl: string;
+  bundleUrl: string;
+}
+
 interface ServerInfo {
   service: string;
   version: string;
   timestamp: string;
+  forms: FormInfo[];
 }
 
 // Increase timeout for server operations
@@ -282,6 +291,19 @@ describe('LocalDeployment', () => {
         expect(info.service).toBe('Emma Forms Local Server');
         expect(info.version).toBe('0.1.0');
         expect(info.timestamp).toBeDefined();
+
+        expect(Array.isArray(info.forms)).toBe(true);
+        expect(info.forms.length).toBeGreaterThan(0);
+        const form = info.forms.find((f) => f.id === 'test-form-001');
+        expect(form).toBeDefined();
+        expect(form?.name).toBe('Test Form');
+        expect(form?.url).toBe('http://localhost:3339/forms/test-form-001/');
+        expect(form?.apiUrl).toBe(
+          'http://localhost:3339/api/submit/test-form-001'
+        );
+        expect(form?.bundleUrl).toBe(
+          'http://localhost:3339/forms/test-form-001/test-form-001.js'
+        );
       },
       TIMEOUT
     );

--- a/packages/form-builder/src/local-deployment.ts
+++ b/packages/form-builder/src/local-deployment.ts
@@ -193,12 +193,36 @@ export class LocalDeployment {
     });
 
     // Server info endpoint
-    this.app.get('/api/info', (_req, res) => {
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    this.app.get('/api/info', async (req, res) => {
+      const formIds = await this.config.listFormSchemas();
+      const schemas = await Promise.all(
+        formIds.map((id) => this.config.loadFormSchema(id))
+      );
+
+      const protocol = req.protocol;
+      const host = req.get('host');
+      const serverUrl = `${protocol}://${host}`;
+
+      const forms = formIds.map((id, index) => {
+        const schema = schemas[index];
+        const timestamp = schema?.currentSnapshot;
+        const bundleName = timestamp ? `${id}-${timestamp}.js` : `${id}.js`;
+
+        return {
+          id,
+          name: schema?.name || id,
+          url: `${serverUrl}/forms/${id}/`,
+          apiUrl: `${serverUrl}/api/submit/${id}`,
+          bundleUrl: `${serverUrl}/forms/${id}/${bundleName}`,
+        };
+      });
+
       res.json({
         service: 'Emma Forms Local Server',
         version: '0.1.0',
         timestamp: new Date().toISOString(),
-        forms: [], // TODO: List available forms
+        forms,
       });
     });
 

--- a/packages/form-builder/src/local-deployment.ts
+++ b/packages/form-builder/src/local-deployment.ts
@@ -195,35 +195,43 @@ export class LocalDeployment {
     // Server info endpoint
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this.app.get('/api/info', async (req, res) => {
-      const formIds = await this.config.listFormSchemas();
-      const schemas = await Promise.all(
-        formIds.map((id) => this.config.loadFormSchema(id))
-      );
+      try {
+        const formIds = await this.config.listFormSchemas();
+        const schemas = await Promise.all(
+          formIds.map((id) => this.config.loadFormSchema(id))
+        );
 
-      const protocol = req.protocol;
-      const host = req.get('host');
-      const serverUrl = `${protocol}://${host}`;
+        const protocol = req.protocol;
+        const host = req.get('host') || 'localhost';
+        const serverUrl = `${protocol}://${host}`;
 
-      const forms = formIds.map((id, index) => {
-        const schema = schemas[index];
-        const timestamp = schema?.currentSnapshot;
-        const bundleName = timestamp ? `${id}-${timestamp}.js` : `${id}.js`;
+        const forms = formIds.map((id, index) => {
+          const schema = schemas[index];
+          const timestamp = schema?.currentSnapshot;
+          const bundleName = timestamp ? `${id}-${timestamp}.js` : `${id}.js`;
 
-        return {
-          id,
-          name: schema?.name || id,
-          url: `${serverUrl}/forms/${id}/`,
-          apiUrl: `${serverUrl}/api/submit/${id}`,
-          bundleUrl: `${serverUrl}/forms/${id}/${bundleName}`,
-        };
-      });
+          return {
+            id,
+            name: schema?.name || id,
+            url: `${serverUrl}/forms/${id}/`,
+            apiUrl: `${serverUrl}/api/submit/${id}`,
+            bundleUrl: `${serverUrl}/forms/${id}/${bundleName}`,
+          };
+        });
 
-      res.json({
-        service: 'Emma Forms Local Server',
-        version: '0.1.0',
-        timestamp: new Date().toISOString(),
-        forms,
-      });
+        res.json({
+          service: 'Emma Forms Local Server',
+          version: '0.1.0',
+          timestamp: new Date().toISOString(),
+          forms,
+        });
+      } catch (error) {
+        console.error('Error in /api/info:', error);
+        res.status(500).json({
+          error: 'Internal Server Error',
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
     });
 
     // Root page with form listing


### PR DESCRIPTION
The `/api/info` endpoint in the local development server was previously returning an empty array for available forms. This PR updates the endpoint to dynamically fetch and return the list of all available forms, including metadata such as form names and absolute URLs for the landing page, API, and JS bundle.

Changes:
- Updated the `/api/info` GET handler in `packages/form-builder/src/local-deployment.ts` to be async and populate the `forms` array.
- Added comprehensive assertions to the `should serve server info` test case in `packages/form-builder/src/__tests__/local-deployment.test.ts`.
- Verified changes with existing unit and integration tests.

---
*PR created automatically by Jules for task [14540169935387634624](https://jules.google.com/task/14540169935387634624) started by @xNok*