### PR TITLE
feat: Make api-worker provider-agnostic and add parity verification

### DIFF
--- a/.github/workflows/provider-parity.yml
+++ b/.github/workflows/provider-parity.yml
@@ -1,0 +1,37 @@
+name: Provider Parity Verification
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  verify-builds:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [cloudflare, vercel, aws, node]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build shared workspace
+        run: yarn build
+        working-directory: ./shared
+
+      - name: Build target (${{ matrix.target }})
+        run: yarn build:${{ matrix.target }}
+        working-directory: ./packages/api-worker

--- a/.github/workflows/provider-parity.yml
+++ b/.github/workflows/provider-parity.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Build shared workspace
         run: yarn build

--- a/packages/api-worker/nitro.config.ts
+++ b/packages/api-worker/nitro.config.ts
@@ -1,18 +1,20 @@
 import { defineNitroConfig } from 'nitropack/config';
 
+const preset = process.env.NITRO_PRESET || 'cloudflare-worker';
+
 export default defineNitroConfig({
   srcDir: 'src',
-  preset: 'cloudflare-worker',
+  preset: preset,
 
   // Compatibility date for Cloudflare Workers
   compatibilityDate: '2024-11-05',
 
-  // Entry point for the H3 app
-  entry: './cloudflare-index.ts',
+  // Use Nitro generic handlers rather than a hardcoded Cloudflare entry point
+  handlers: [{ route: '/**', handler: '~/server.ts' }],
 
-  // Output directory - use dist/cloudflare for multi-provider support
+  // Dynamically set output directory based on preset for multi-provider support
   output: {
-    dir: 'dist/cloudflare',
+    dir: `dist/${preset}`,
   },
 
   // Cloudflare-specific configuration with wrangler settings

--- a/packages/api-worker/package.json
+++ b/packages/api-worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xnok/emma-api-worker",
   "version": "0.4.0",
-  "description": "Cloudflare Worker for handling form submissions",
+  "description": "Provider-agnostic API worker for handling form submissions (Cloudflare, Vercel Edge, AWS Lambda, Node.js)",
   "type": "module",
   "scripts": {
     "build": "yarn build:cloudflare && yarn build:node && yarn build:vercel && yarn build:aws",

--- a/packages/api-worker/package.json
+++ b/packages/api-worker/package.json
@@ -3,17 +3,18 @@
   "version": "0.4.0",
   "description": "Cloudflare Worker for handling form submissions",
   "type": "module",
-  "main": "./src/cloudflare-index.ts",
   "scripts": {
-    "build": "yarn build:cloudflare && yarn build:node",
-    "build:cloudflare": "nitro build --preset cloudflare",
-    "build:node": "nitro build --preset node-server",
+    "build": "yarn build:cloudflare && yarn build:node && yarn build:vercel && yarn build:aws",
+    "build:cloudflare": "NITRO_PRESET=cloudflare-worker nitro build",
+    "build:node": "NITRO_PRESET=node-server nitro build",
     "dev": "nitro dev",
-    "dev:cloudflare": "wrangler dev dist/cloudflare/server/index.mjs --site dist/cloudflare/public --remote",
+    "dev:cloudflare": "wrangler dev dist/cloudflare-worker/server/index.mjs --site dist/cloudflare-worker/public --remote",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "generate:types": "openapi-typescript openapi.yaml --output src/types.ts"
+    "generate:types": "openapi-typescript openapi.yaml --output src/types.ts",
+    "build:vercel": "NITRO_PRESET=vercel-edge nitro build",
+    "build:aws": "NITRO_PRESET=aws-lambda nitro build"
   },
   "dependencies": {
     "@xnok/emma-shared": "workspace:*",

--- a/packages/provider-cloudflare/src/__tests__/api-worker-deployment.test.ts
+++ b/packages/provider-cloudflare/src/__tests__/api-worker-deployment.test.ts
@@ -97,7 +97,7 @@ describe('ApiWorkerDeployment', () => {
       );
     });
 
-    it('should check for Nitro build output at dist/cloudflare/server/index.mjs', async () => {
+    it('should check for Nitro build output at dist/cloudflare-worker/server/index.mjs', async () => {
       // Mock fs.readJSON for package.json
       vi.mocked(fs.readJSON).mockResolvedValue({
         name: '@xnok/emma-api-worker',
@@ -182,7 +182,9 @@ describe('ApiWorkerDeployment', () => {
         // Expect specific error about worker script not found
         expect(error).toBeInstanceOf(Error);
         if (error instanceof Error) {
-          expect(error.message).toContain('dist/cloudflare/server/index.mjs');
+          expect(error.message).toContain(
+            'dist/cloudflare-worker/server/index.mjs'
+          );
           expect(error.message).toContain('built');
         }
       }

--- a/shared/utils/__tests__/api-worker-resolver.test.ts
+++ b/shared/utils/__tests__/api-worker-resolver.test.ts
@@ -21,23 +21,31 @@ describe('API Worker Resolver', () => {
     // Create mock package structure
     await fs.ensureDir(mockPackageDir);
     await fs.ensureDir(
-      path.join(mockPackageDir, 'dist', 'cloudflare', 'server')
+      path.join(mockPackageDir, 'dist', 'cloudflare-worker', 'server')
     );
-    await fs.ensureDir(path.join(mockPackageDir, 'dist', 'node', 'server'));
+    await fs.ensureDir(
+      path.join(mockPackageDir, 'dist', 'node-server', 'server')
+    );
 
     // Create mock package.json
     await fs.writeJSON(path.join(mockPackageDir, 'package.json'), {
       name: '@xnok/emma-api-worker',
-      version: '1.0.0',
+      version: '0.4.0',
     });
 
     // Create mock worker scripts
     await fs.writeFile(
-      path.join(mockPackageDir, 'dist', 'cloudflare', 'server', 'index.mjs'),
+      path.join(
+        mockPackageDir,
+        'dist',
+        'cloudflare-worker',
+        'server',
+        'index.mjs'
+      ),
       'export default { fetch: () => new Response("cloudflare") };'
     );
     await fs.writeFile(
-      path.join(mockPackageDir, 'dist', 'node', 'server', 'index.mjs'),
+      path.join(mockPackageDir, 'dist', 'node-server', 'server', 'index.mjs'),
       'export default { fetch: () => new Response("node") };'
     );
   });
@@ -53,18 +61,23 @@ describe('API Worker Resolver', () => {
     it('should resolve cloudflare worker script', async () => {
       // Mock require.resolve to return our test package
       const originalResolve = require.resolve;
-      require.resolve = ((id: string) => {
-        if (id === '@xnok/emma-api-worker/package.json') {
+      require.resolve = ((id: string, options?: { paths?: string[] }) => {
+        if (
+          id === '@xnok/emma-api-worker/package.json' ||
+          id.startsWith('@xnok/emma-api-worker/package.json')
+        ) {
           return path.join(mockPackageDir, 'package.json');
         }
-        return originalResolve(id);
+        return originalResolve(id, options);
       }) as typeof require.resolve;
 
       const result = await resolveApiWorker({ platform: 'cloudflare' });
 
-      expect(result.packageVersion).toBe('1.0.0');
+      expect(result.packageVersion).toBe('0.4.0');
       expect(result.scriptContent).toContain('cloudflare');
-      expect(result.scriptPath).toContain('dist/cloudflare/server/index.mjs');
+      expect(result.scriptPath).toContain(
+        'dist/cloudflare-worker/server/index.mjs'
+      );
       expect(result.packageDir).toBe(mockPackageDir);
 
       // Restore original require.resolve
@@ -73,29 +86,35 @@ describe('API Worker Resolver', () => {
 
     it('should resolve node worker script', async () => {
       const originalResolve = require.resolve;
-      require.resolve = ((id: string) => {
-        if (id === '@xnok/emma-api-worker/package.json') {
+      require.resolve = ((id: string, options?: { paths?: string[] }) => {
+        if (
+          id === '@xnok/emma-api-worker/package.json' ||
+          id.startsWith('@xnok/emma-api-worker/package.json')
+        ) {
           return path.join(mockPackageDir, 'package.json');
         }
-        return originalResolve(id);
+        return originalResolve(id, options);
       }) as typeof require.resolve;
 
       const result = await resolveApiWorker({ platform: 'node' });
 
-      expect(result.packageVersion).toBe('1.0.0');
+      expect(result.packageVersion).toBe('0.4.0');
       expect(result.scriptContent).toContain('node');
-      expect(result.scriptPath).toContain('dist/node/server/index.mjs');
+      expect(result.scriptPath).toContain('dist/node-server/server/index.mjs');
 
       require.resolve = originalResolve;
     });
 
     it('should throw error if package not found', async () => {
       const originalResolve = require.resolve;
-      require.resolve = ((id: string) => {
-        if (id === '@xnok/emma-api-worker/package.json') {
+      require.resolve = ((id: string, options?: { paths?: string[] }) => {
+        if (
+          id === '@xnok/emma-api-worker/package.json' ||
+          id.startsWith('@xnok/emma-api-worker/package.json')
+        ) {
           throw new Error('Cannot find module');
         }
-        return originalResolve(id);
+        return originalResolve(id, options);
       }) as typeof require.resolve;
 
       await expect(
@@ -107,14 +126,18 @@ describe('API Worker Resolver', () => {
 
     it('should throw error if built script not found', async () => {
       const originalResolve = require.resolve;
-      require.resolve = ((id: string) => {
-        if (id === '@xnok/emma-api-worker/package.json') {
+      require.resolve = ((id: string, options?: { paths?: string[] }) => {
+        if (
+          id === '@xnok/emma-api-worker/package.json' ||
+          id.startsWith('@xnok/emma-api-worker/package.json')
+        ) {
           return path.join(mockPackageDir, 'package.json');
         }
-        return originalResolve(id);
+        return originalResolve(id, options);
       }) as typeof require.resolve;
 
       // Remove the built script
+      await fs.remove(path.join(mockPackageDir, 'dist', 'cloudflare-worker'));
       await fs.remove(path.join(mockPackageDir, 'dist', 'cloudflare'));
 
       await expect(
@@ -130,11 +153,14 @@ describe('API Worker Resolver', () => {
         .spyOn(console, 'warn')
         .mockImplementation(() => {});
 
-      require.resolve = ((id: string) => {
-        if (id === '@xnok/emma-api-worker/package.json') {
+      require.resolve = ((id: string, options?: { paths?: string[] }) => {
+        if (
+          id === '@xnok/emma-api-worker/package.json' ||
+          id.startsWith('@xnok/emma-api-worker/package.json')
+        ) {
           return path.join(mockPackageDir, 'package.json');
         }
-        return originalResolve(id);
+        return originalResolve(id, options);
       }) as typeof require.resolve;
 
       await resolveApiWorker({
@@ -143,7 +169,7 @@ describe('API Worker Resolver', () => {
       });
 
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Requested version 2.0.0 but found 1.0.0')
+        expect.stringContaining('Requested version 2.0.0 but found 0.4.0')
       );
 
       consoleWarnSpy.mockRestore();
@@ -154,26 +180,32 @@ describe('API Worker Resolver', () => {
   describe('getApiWorkerVersion', () => {
     it('should return package version', async () => {
       const originalResolve = require.resolve;
-      require.resolve = ((id: string) => {
-        if (id === '@xnok/emma-api-worker/package.json') {
+      require.resolve = ((id: string, options?: { paths?: string[] }) => {
+        if (
+          id === '@xnok/emma-api-worker/package.json' ||
+          id.startsWith('@xnok/emma-api-worker/package.json')
+        ) {
           return path.join(mockPackageDir, 'package.json');
         }
-        return originalResolve(id);
+        return originalResolve(id, options);
       }) as typeof require.resolve;
 
       const version = await getApiWorkerVersion();
-      expect(version).toBe('1.0.0');
+      expect(version).toBe('0.4.0');
 
       require.resolve = originalResolve;
     });
 
     it('should return null if package not found', async () => {
       const originalResolve = require.resolve;
-      require.resolve = ((id: string) => {
-        if (id === '@xnok/emma-api-worker/package.json') {
+      require.resolve = ((id: string, options?: { paths?: string[] }) => {
+        if (
+          id === '@xnok/emma-api-worker/package.json' ||
+          id.startsWith('@xnok/emma-api-worker/package.json')
+        ) {
           throw new Error('Cannot find module');
         }
-        return originalResolve(id);
+        return originalResolve(id, options);
       }) as typeof require.resolve;
 
       const version = await getApiWorkerVersion();

--- a/shared/utils/api-worker-resolver.ts
+++ b/shared/utils/api-worker-resolver.ts
@@ -4,7 +4,11 @@
  */
 
 import path from 'path';
+import { fileURLToPath } from 'url';
 import fs from 'fs-extra';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 export interface WorkerResolutionResult {
   scriptPath: string;

--- a/shared/utils/api-worker-resolver.ts
+++ b/shared/utils/api-worker-resolver.ts
@@ -36,7 +36,16 @@ export async function resolveApiWorker(
   let packageJson: { name: string; version: string };
 
   try {
-    const packageJsonPath = require.resolve(`${packageName}/package.json`);
+    // We try to resolve first naturally
+    let packageJsonPath: string;
+    try {
+      packageJsonPath = require.resolve(`${packageName}/package.json`);
+    } catch (e) {
+      // If not found, use explicit paths
+      packageJsonPath = require.resolve(`${packageName}/package.json`, {
+        paths: [process.cwd(), __dirname],
+      });
+    }
     workerPackageDir = path.dirname(packageJsonPath);
     packageJson = (await fs.readJSON(packageJsonPath)) as {
       name: string;
@@ -49,18 +58,26 @@ export async function resolveApiWorker(
   }
 
   // 2. Find the pre-built script file
-  // This path matches the build output: dist/{platform}/server/index.mjs
+  // The path differs slightly depending on the Nitro preset target
+  let platformSubdir: string = options.platform;
+
+  if (options.platform === 'cloudflare') {
+    platformSubdir = 'cloudflare-worker';
+  } else if (options.platform === 'node') {
+    platformSubdir = 'node-server';
+  }
+
   const scriptPath = path.join(
     workerPackageDir,
     'dist',
-    options.platform,
+    platformSubdir,
     'server',
     'index.mjs'
   );
 
   if (!(await fs.pathExists(scriptPath))) {
     throw new Error(
-      `Error: Could not find pre-built file at ${scriptPath}. ` +
+      `Could not find pre-built file at ${scriptPath}. ` +
         `Make sure the package has been built for platform '${options.platform}'.`
     );
   }
@@ -93,7 +110,9 @@ export async function getApiWorkerVersion(
   packageName = '@xnok/emma-api-worker'
 ): Promise<string | null> {
   try {
-    const packageJsonPath = require.resolve(`${packageName}/package.json`);
+    const packageJsonPath = require.resolve(`${packageName}/package.json`, {
+      paths: [process.cwd(), __dirname],
+    });
     const packageJson = (await fs.readJSON(packageJsonPath)) as {
       version: string;
     };


### PR DESCRIPTION
This pull request abstracts the `api-worker` package to be truly provider-agnostic, breaking its tight coupling with Cloudflare Workers. 

It achieves this by leveraging `nitropack`'s built-in presets dynamically via the `NITRO_PRESET` environment variable. The hardcoded Cloudflare entry point has been replaced with a universal Nitro `handlers` array, allowing the worker to be deployed to targets like Vercel Edge, AWS Lambda, and Node.js environments.

Additionally, this PR adds a GitHub Actions matrix workflow (`provider-parity.yml`) to ensure compilation parity across all supported environments, reinforcing the project's vision of provider-agnostic Edge/WASM patterns.

---
*PR created automatically by Jules for task [5752432822295749939](https://jules.google.com/task/5752432822295749939) started by @xNok*